### PR TITLE
Fix Categories API when name query param is passed

### DIFF
--- a/controllers/category.js
+++ b/controllers/category.js
@@ -1,6 +1,9 @@
 const Category = require("../models/Category.schema");
 const categoriesRaw = require("../data/roles.json");
-const categories = Object.keys(categoriesRaw).map(category => ({ category, roles: Object.keys(categoriesRaw[category]) }));
+const categories = Object.keys(categoriesRaw).map((category) => ({
+  category,
+  roles: Object.keys(categoriesRaw[category]),
+}));
 
 /*
 const cache = {};
@@ -45,18 +48,20 @@ const flush = async () => {
 };
 */
 const find = async ({ limit, offset, name }) => {
-	if(name){
-		const category = categoriesKeywords[name];
-		const roles = categories[category];
+  if (name) {
+    const category = Object.keys(categoriesRaw).find((cat) => cat === name);
+    if (!category) throw new Error("category not found");
 
-		return { category, roles };
-	}
+    const roles = Object.keys(categoriesRaw[category]);
 
-	return categories.slice(offset, limit);
+    return { category, roles };
+  }
+
+  return categories.slice(offset, limit);
 };
 
 module.exports = {
-//	incVisits,
-//	flush,
-	find
+  //	incVisits,
+  //	flush,
+  find,
 };


### PR DESCRIPTION
Fix for issue #10

Category API is now fixed to accept name param as input and fetch the associated roles accordindly